### PR TITLE
fix blackhole override

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # Transit Gateway Centralized Router
 - Creates hub and spoke topology from VPCs.
 
+`v1.0.4`
+- ability to switch between a blackhole route and a static route that have the same cidr/ipv6\_cidr for vpc attachments.
+
 `v1.0.3`
 - support for building IPv6 VPC routes for IPv6 secondary cidrs including variable validation.
-- updated generat\_routes\_to\_vpcs module test suite with IPv6 VPC route tests.
+- updated generate\_routes\_to\_vpcs module test suite with IPv6 VPC route tests.
 - build TGW static IPv4 and IPv6 routes for vpc attachments by default which is more ideal.
 - can now toggle route propagation for vpc attachments but disabled by default.
 - requires AWS provider version `>=5.61`

--- a/blackhole_routes.tf
+++ b/blackhole_routes.tf
@@ -9,4 +9,6 @@ resource "aws_ec2_transit_gateway_route" "this_blackholes" {
   destination_cidr_block         = each.value
   blackhole                      = true
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.this.id
+
+  depends_on = [aws_ec2_transit_gateway_route.this_tgw_routes_to_vpcs, aws_ec2_transit_gateway_route.this_tgw_ipv6_routes_to_vpcs]
 }

--- a/main.tf
+++ b/main.tf
@@ -2,9 +2,12 @@
 * # Transit Gateway Centralized Router
 * - Creates hub and spoke topology from VPCs.
 *
+* `v1.0.4`
+* - ability to switch between a blackhole route and a static route that have the same cidr/ipv6_cidr for vpc attachments.
+*
 * `v1.0.3`
 * - support for building IPv6 VPC routes for IPv6 secondary cidrs including variable validation.
-* - updated generat_routes_to_vpcs module test suite with IPv6 VPC route tests.
+* - updated generate_routes_to_vpcs module test suite with IPv6 VPC route tests.
 * - build TGW static IPv4 and IPv6 routes for vpc attachments by default which is more ideal.
 * - can now toggle route propagation for vpc attachments but disabled by default.
 * - requires AWS provider version `>=5.61`

--- a/tgw_routes.tf
+++ b/tgw_routes.tf
@@ -3,6 +3,7 @@ locals {
     for this in var.centralized_router.vpcs : {
       for network_cidr in concat([this.network_cidr], this.secondary_cidrs) :
       network_cidr => this.id
+      if !contains(var.centralized_router.blackhole.cidrs, network_cidr)
   }]...)
 }
 
@@ -19,6 +20,7 @@ locals {
     for this in var.centralized_router.vpcs : {
       for ipv6_network_cidr in concat(compact([this.ipv6_network_cidr]), this.ipv6_secondary_cidrs) :
       ipv6_network_cidr => this.id
+      if !contains(var.centralized_router.blackhole.ipv6_cidrs, ipv6_network_cidr)
   }]...)
 }
 


### PR DESCRIPTION
- ability to switch between a blackhole route and a static route that have the same cidr/ipv6\_cidr for vpc attachments.
