### PR TITLE
remove legacy output vpc.routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Transit Gateway Centralized Router
 - Creates hub and spoke topology from VPCs.
 
+`v1.0.6`
+- remove legacy output `vpc.routes`. will rebuild super router at a later time but no need to keep this around.
+
 `v1.0.5`
 - support for VPC centralized egress modes when passed to centralized router with validation
   - when a VPC has `central = true` create `0.0.0.0/0` route on tgw route table

--- a/base.tf
+++ b/base.tf
@@ -14,6 +14,15 @@ locals {
   }, var.tags)
 
   centralized_router_name = format("%s-%s-%s-%s", local.upper_env_prefix, "centralized-router", var.centralized_router.name, local.region_label)
+
+  # add the vpc and it's azs the to the mesh if there's 1 or more AZs with special = true
+  # if there are no AZs with special = true then the VPC is fully removed from the mesh (vpc and tgw routes)
+  # making it easier to decomission AZs and VPCs without manual intervention
+  vpcs = {
+    for this in var.centralized_router.vpcs :
+    this.id => this
+    if length(concat(this.private_special_subnet_ids, this.public_special_subnet_ids)) > 0
+  }
 }
 
 # one tgw that will route between all tiered vpcs.

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,9 @@
 * # Transit Gateway Centralized Router
 * - Creates hub and spoke topology from VPCs.
 *
+* `v1.0.6`
+* - remove legacy output `vpc.routes`. will rebuild super router at a later time but no need to keep this around.
+*
 * `v1.0.5`
 * - support for VPC centralized egress modes when passed to centralized router with validation
 *   - when a VPC has `central = true` create `0.0.0.0/0` route on tgw route table

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,9 +35,6 @@ output "route_table_id" {
 }
 
 output "vpc" {
-  # vpc.routes list of objects will only have 3 attributes (per object) instead of all attributes from the route
-  # makes it easier to see when troubleshooting many vpc routes and is used for super router
-  # otherwise it can just be [for this in aws_route.this_vpc_routes_to_other_vpcs : this]
   value = {
     names                   = [for this in local.vpcs : this.name]
     network_cidrs           = [for this in local.vpcs : this.network_cidr]
@@ -46,13 +43,6 @@ output "vpc" {
     ipv6_secondary_cidrs    = flatten([for this in local.vpcs : this.ipv6_secondary_cidrs])
     private_route_table_ids = flatten([for this in local.vpcs : this.private_route_table_ids])
     public_route_table_ids  = flatten([for this in local.vpcs : this.public_route_table_ids])
-    # outputing routes is legacy, easier to construct routes from route table ids and network cidrs when
-    # passed to another module like full mesh trio but is still used with super router until it's refactored.
-    routes = [
-      for this in aws_route.this_vpc_routes_to_other_vpcs : {
-        route_table_id         = this.route_table_id
-        destination_cidr_block = this.destination_cidr_block
-        transit_gateway_id     = this.transit_gateway_id
-    }]
   }
 }
+

--- a/vpc_routes.tf
+++ b/vpc_routes.tf
@@ -1,14 +1,3 @@
-locals {
-  # add the vpc and it's azs the to the mesh if there's 1 or more AZs with special = true
-  # if there are no AZs with special = true then the VPC is fully removed from the mesh (vpc and tgw routes)
-  # making it easier to decomission AZs and VPCs without manual intervention
-  vpcs = {
-    for this in var.centralized_router.vpcs :
-    this.id => this
-    if length(concat(this.private_special_subnet_ids, this.public_special_subnet_ids)) > 0
-  }
-}
-
 # Create routes to other VPC network_cidrs in private and public route tables for each VPC
 module "this_generate_routes_to_other_vpcs" {
   source = "./modules/generate_routes_to_other_vpcs"


### PR DESCRIPTION
- remove legacy output `vpc.routes`. will rebuild super router at a later time but no need to keep this around.
